### PR TITLE
secretKey 디코딩 문제 해결 및 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/sparta/gathering/common/config/JwtFilter.java
+++ b/src/main/java/com/sparta/gathering/common/config/JwtFilter.java
@@ -1,5 +1,7 @@
 package com.sparta.gathering.common.config;
 
+import com.sparta.gathering.common.exception.BaseException;
+import com.sparta.gathering.common.exception.ExceptionEnum;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -37,10 +39,9 @@ public class JwtFilter extends OncePerRequestFilter {
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain chain) throws IOException {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        log.info("Authorization 헤더: {}", bearerToken);
         if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
-            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "JWT 토큰이 필요합니다.");
-            log.warn("JWT 토큰이 필요합니다.");
-            return;
+            throw new IllegalArgumentException("JWT 토큰이 누락되었습니다.");
         }
 
         try {
@@ -72,7 +73,7 @@ public class JwtFilter extends OncePerRequestFilter {
         // subject에서 UUID 변환
         UUID uuid = UUID.fromString(claims.getSubject()); // UUID로 변환
 
-        // 정적 팩토리 메서드를 사용하여 User 객체 생성
+        // User 객체 생성
         User user = User.createWithMinimumInfo(uuid, email, nickName, userRole);
 
         UsernamePasswordAuthenticationToken authentication =

--- a/src/main/java/com/sparta/gathering/common/config/JwtTokenProvider.java
+++ b/src/main/java/com/sparta/gathering/common/config/JwtTokenProvider.java
@@ -35,8 +35,13 @@ public class JwtTokenProvider {
 
     @PostConstruct
     public void init() {
-        byte[] bytes = Base64.getDecoder().decode(secretKey);
-        key = Keys.hmacShaKeyFor(bytes);
+        if (secretKey == null || secretKey.isEmpty()) {
+            throw new IllegalArgumentException("JWT secret key를 찾을 수 없습니다.");
+        }
+
+        byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(decodedKey);
+        log.info("JWT 서명 키가 정상적으로 설정되었습니다.");
     }
 
     public String createToken(UUID userId, String email, String nickname , UserRole userRole) {
@@ -62,10 +67,15 @@ public class JwtTokenProvider {
     }
 
     public Claims extractClaims(String token) {
+        if (key == null) {
+            log.error("JWT 서명 키가 null입니다.");
+            throw new IllegalArgumentException("JWT 서명 키가 null입니다.");
+        }
         return Jwts.parserBuilder()
                 .setSigningKey(key)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
     }
+
 }

--- a/src/main/java/com/sparta/gathering/common/exception/ExceptionEnum.java
+++ b/src/main/java/com/sparta/gathering/common/exception/ExceptionEnum.java
@@ -10,14 +10,20 @@ public enum ExceptionEnum {
     DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "DATA_INTEGRITY_VIOLATION", "데이터 처리 중 문제가 발생했습니다. 요청을 확인하고 다시 시도해주세요"),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버에서 문제가 발생했습니다."),
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "INVALID_INPUT_VALUE", "요청 값이 올바르지 않습니다."),
+    UNAUTHORIZED_ACTION(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_ACTION", "권한이 없습니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "INVALID_USER_ID", "유저 ID가 올바르지 않습니다."),
 
     // 토큰 관련
-    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN_NOT,FOUND", "토큰을 찾을 수 없습니다."),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "TOKEN_NOT,FOUND", "토큰이 누락되었습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "인증 기간이 만료되었습니다."),
+    INVALID_CLAIMS(HttpStatus.UNAUTHORIZED, "INVALID_CLAIMS", "토큰 클레임이 올바르지 않습니다."),
 
     // 유저 관련
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+    ALREADY_DELETED(HttpStatus.BAD_REQUEST, "ALREADY_DELETED", "이미 탈퇴된 사용자입니다."),
     USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER_ALREADY_EXISTS", "이미 존재하는 사용자입니다."),
     EMAIL_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "EMAIL_PASSWORD_MISMATCH", "이메일 혹은 비밀번호가 일치하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String errorCode;

--- a/src/main/java/com/sparta/gathering/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/gathering/common/exception/GlobalExceptionHandler.java
@@ -20,7 +20,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleBaseException(BaseException ex) {
         log.error("BaseException: ", ex);
         return ResponseEntity.status(ex.getStatus())
-                .body(ApiResponse.errorWithoutData(ex.getExceptionEnum(), ex.getStatus()));
+                .body(ApiResponse.errorWithOutData(ex.getExceptionEnum(), ex.getStatus()));
     }
 
     // SQL 무결성 예외 처리
@@ -28,7 +28,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleSQLIntegrityConstraintViolationException(SQLIntegrityConstraintViolationException ex) {
         log.error("SQLIntegrityConstraintViolationException: ", ex);
         return ResponseEntity.status(ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus())
-                .body(ApiResponse.errorWithoutData(ExceptionEnum.DATA_INTEGRITY_VIOLATION, ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus()));
+                .body(ApiResponse.errorWithOutData(ExceptionEnum.DATA_INTEGRITY_VIOLATION, ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus()));
     }
 
     // 데이터 무결성 예외 처리
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleDataIntegrityViolationException(org.springframework.dao.DataIntegrityViolationException ex) {
         log.error("DataIntegrityViolationException: ", ex);
         return ResponseEntity.status(ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus())
-                .body(ApiResponse.errorWithoutData(ExceptionEnum.DATA_INTEGRITY_VIOLATION, ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus()));
+                .body(ApiResponse.errorWithOutData(ExceptionEnum.DATA_INTEGRITY_VIOLATION, ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus()));
     }
 
     // @Valid 검증 실패 시 발생하는 예외 처리

--- a/src/main/java/com/sparta/gathering/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sparta/gathering/common/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package com.sparta.gathering.common.exception;
 
 import com.sparta.gathering.common.response.ApiResponse;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -32,16 +35,16 @@ public class GlobalExceptionHandler {
     }
 
     // 데이터 무결성 예외 처리
-    @ExceptionHandler(org.springframework.dao.DataIntegrityViolationException.class)
-    public ResponseEntity<ApiResponse<?>> handleDataIntegrityViolationException(org.springframework.dao.DataIntegrityViolationException ex) {
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
         log.error("DataIntegrityViolationException: ", ex);
         return ResponseEntity.status(ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus())
                 .body(ApiResponse.errorWithOutData(ExceptionEnum.DATA_INTEGRITY_VIOLATION, ExceptionEnum.DATA_INTEGRITY_VIOLATION.getStatus()));
     }
 
     // @Valid 검증 실패 시 발생하는 예외 처리
-    @ExceptionHandler(org.springframework.web.bind.MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(org.springframework.web.bind.MethodArgumentNotValidException ex) {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         log.error("MethodArgumentNotValidException: ", ex);
         // 유효성 검사 실패 시 발생한 오류 메시지를 필드별로 저장
         Map<String, String> errors = new HashMap<>();
@@ -52,7 +55,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ExceptionEnum.INVALID_INPUT_VALUE.getStatus())
                 .body(ApiResponse.errorWithData(ExceptionEnum.INVALID_INPUT_VALUE, ExceptionEnum.INVALID_INPUT_VALUE.getStatus(), errors));
     }
-
 
     /*// 그 외 예상치 못한 예외 처리
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/sparta/gathering/common/response/ApiResponse.java
+++ b/src/main/java/com/sparta/gathering/common/response/ApiResponse.java
@@ -31,7 +31,7 @@ public class ApiResponse<T> {
     }
 
     // 성공 응답 메서드 (데이터 없이)
-    public static <T> ApiResponse<T> successWithoutData(ApiResponseEnum messageEnum) {
+    public static <T> ApiResponse<T> successWithOutData(ApiResponseEnum messageEnum) {
         return new ApiResponse<>(null, messageEnum);
     }
 
@@ -41,7 +41,7 @@ public class ApiResponse<T> {
     }
 
     // 에러 응답 메서드 (데이터 없이)
-    public static ApiResponse<?> errorWithoutData(ExceptionEnum exceptionEnum, HttpStatus status) {
+    public static ApiResponse<?> errorWithOutData(ExceptionEnum exceptionEnum, HttpStatus status) {
         return new ApiResponse<>(exceptionEnum, status, null);
     }
 

--- a/src/main/java/com/sparta/gathering/common/response/ApiResponseEnum.java
+++ b/src/main/java/com/sparta/gathering/common/response/ApiResponseEnum.java
@@ -7,7 +7,7 @@ public enum ApiResponseEnum {
 
     // 유저 관련
     SIGNUP_SUCCESS("회원가입이 완료되었습니다. 로그인 화면으로 이동합니다."),
-    USER_DELETED_SUCCESS("회원 탈퇴가 완료되었습니다.");
+    USER_DELETED_SUCCESS("회원 탈퇴가 완료되었습니다. 이용해 주셔서 감사합니다.");
 
     private final String message;
 

--- a/src/main/java/com/sparta/gathering/domain/user/controller/AuthController.java
+++ b/src/main/java/com/sparta/gathering/domain/user/controller/AuthController.java
@@ -3,23 +3,14 @@ package com.sparta.gathering.domain.user.controller;
 
 import com.sparta.gathering.common.config.JwtTokenProvider;
 import com.sparta.gathering.domain.user.dto.request.LoginRequest;
-import com.sparta.gathering.domain.user.dto.request.RefreshTokenRequest;
 import com.sparta.gathering.domain.user.entity.User;
-import com.sparta.gathering.domain.user.enums.IdentityProvider;
-import com.sparta.gathering.domain.user.enums.UserRole;
+
 import com.sparta.gathering.domain.user.service.RefreshTokenService;
 import com.sparta.gathering.domain.user.service.UserService;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -42,52 +33,9 @@ public class AuthController {
         User user = userService.authenticateUser(loginRequest.getEmail(), loginRequest.getPassword());
         String token = jwtTokenProvider.createToken(user.getId(), user.getEmail(), user.getNickName(), user.getUserRole());
         return ResponseEntity.ok()
-                .header("Authorization", "Bearer " + token)
+                .header("Authorization", token)
                 .build();
     }
-
-   /* 보류 ############################################################
-   // 소셜 로그인 성공 후, JWT 토큰 발급
-    @PostMapping("/oauth2/login-success")
-    public ResponseEntity<Map<String, String>> oauth2LoginSuccess(Authentication authentication) {
-        OAuth2User oauthUser = (OAuth2User) authentication.getPrincipal();
-
-        String providerId = oauthUser.getAttribute("sub"); // OAuth2 제공자별 ID 가져오기 (구글은 "sub", 카카오는 다름)
-        String email = oauthUser.getAttribute("email");
-
-        User user = userService.findByProviderIdAndIdentityProvider(providerId, IdentityProvider.GOOGLE); // 구글 예시
-        if (user == null) {
-            // 소셜 계정으로 새 사용자 생성
-            user = userService.createUser(email, oauthUser.getAttribute("name"), null, UserRole.ROLE_USER, IdentityProvider.GOOGLE);
-        }
-
-        String token = jwtTokenProvider.createToken(user.getId());
-        String refreshToken = refreshTokenService.createRefreshToken(user);
-
-        Map<String, String> response = new HashMap<>();
-        response.put("access_token", token);
-        response.put("refresh_token", refreshToken);
-
-        return ResponseEntity.ok(response);
-    }
-
-    // Refresh Token를 통해 Access Token 재발급
-    @PostMapping("/token/refresh")
-    public ResponseEntity<Map<String, String>> refreshToken(@RequestBody RefreshTokenRequest refreshTokenRequest) {
-        boolean isValid = refreshTokenService.validateRefreshToken(refreshTokenRequest.getRefreshToken());
-
-        if (!isValid) {
-            throw new RuntimeException("Invalid refresh token");
-        }
-
-        User user = refreshTokenService.findUserByRefreshToken(refreshTokenRequest.getRefreshToken());
-        String newToken = jwtTokenProvider.createToken(user.getId());
-
-        Map<String, String> response = new HashMap<>();
-        response.put("access_token", newToken);
-
-        return ResponseEntity.ok(response);
-    }*/
 
 }
 

--- a/src/main/java/com/sparta/gathering/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/gathering/domain/user/controller/UserController.java
@@ -3,12 +3,11 @@ package com.sparta.gathering.domain.user.controller;
 import com.sparta.gathering.common.config.JwtTokenProvider;
 import com.sparta.gathering.common.response.ApiResponse;
 import com.sparta.gathering.common.response.ApiResponseEnum;
-import com.sparta.gathering.domain.user.entity.User;
 import com.sparta.gathering.domain.user.service.UserService;
 import com.sparta.gathering.domain.user.dto.request.UserRequest;
-import com.sparta.gathering.domain.user.dto.response.UserResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
 
+@Slf4j
 @Tag(name = "User", description = "사용자 API")
 @RestController
 @RequestMapping("/api/users")
@@ -24,11 +24,13 @@ public class UserController {
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Autowired
-    public UserController(UserService userService, PasswordEncoder passwordEncoder) {
+    public UserController(UserService userService, PasswordEncoder passwordEncoder, JwtTokenProvider JwtTokenProvider) {
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = JwtTokenProvider;
     }
 
     // 회원가입
@@ -37,16 +39,18 @@ public class UserController {
         userRequest.setPassword(passwordEncoder.encode(userRequest.getPassword()));
         userService.createUser(userRequest);
         ApiResponse<Void> response = ApiResponse.successWithOutData(ApiResponseEnum.SIGNUP_SUCCESS);
-        // 201 Created 상태와 함께 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    // 사용자 삭제 (Soft Delete)
-    @DeleteMapping("/{userId}")
-    public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable UUID userId) {
-        userService.deleteUser(userId);
+    // 회원 탈퇴 (Soft Delete)
+    @PatchMapping("/{userId}")
+    public ResponseEntity<ApiResponse<Void>> deleteUser(
+            @PathVariable UUID userId,
+            @RequestHeader("Authorization") String token) {
+        String tokenUserId = jwtTokenProvider.extractClaims(jwtTokenProvider.substringToken(token)).getSubject();
+        userService.deleteUser(userId, tokenUserId);
         ApiResponse<Void> response = ApiResponse.successWithOutData(ApiResponseEnum.USER_DELETED_SUCCESS);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 }

--- a/src/main/java/com/sparta/gathering/domain/user/controller/UserController.java
+++ b/src/main/java/com/sparta/gathering/domain/user/controller/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
     public ResponseEntity<ApiResponse<Void>> signup(@Valid @RequestBody UserRequest userRequest) {
         userRequest.setPassword(passwordEncoder.encode(userRequest.getPassword()));
         userService.createUser(userRequest);
-        ApiResponse<Void> response = ApiResponse.successWithoutData(ApiResponseEnum.SIGNUP_SUCCESS);
+        ApiResponse<Void> response = ApiResponse.successWithOutData(ApiResponseEnum.SIGNUP_SUCCESS);
         // 201 Created 상태와 함께 응답 반환
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -45,7 +45,7 @@ public class UserController {
     @DeleteMapping("/{userId}")
     public ResponseEntity<ApiResponse<Void>> deleteUser(@PathVariable UUID userId) {
         userService.deleteUser(userId);
-        ApiResponse<Void> response = ApiResponse.successWithoutData(ApiResponseEnum.USER_DELETED_SUCCESS);
+        ApiResponse<Void> response = ApiResponse.successWithOutData(ApiResponseEnum.USER_DELETED_SUCCESS);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
     }
 

--- a/src/main/java/com/sparta/gathering/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/sparta/gathering/domain/user/dto/request/UserRequest.java
@@ -24,6 +24,7 @@ public class UserRequest {
     @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하로 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "로그인 제공자가 올바르지 않습니다.")
     private IdentityProvider identityProvider; // NONE, GOOGLE, KAKAO 중 선택
 
 }

--- a/src/main/java/com/sparta/gathering/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/gathering/domain/user/entity/User.java
@@ -94,7 +94,7 @@ public class User extends Timestamped {
     }
 
     // 소프트 삭제
-    public void deleteUser() {
+    public void setDeletedAt() {
         this.deletedAt = LocalDateTime.now();
     }
 

--- a/src/main/java/com/sparta/gathering/domain/user/service/RefreshTokenServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/user/service/RefreshTokenServiceImpl.java
@@ -23,7 +23,7 @@ public class RefreshTokenServiceImpl implements RefreshTokenService {
     @Override
     public String createRefreshToken(User user) {
         String token = UUID.randomUUID().toString();
-        Timestamp expiryDate = new Timestamp(new Date().getTime() + 604800000); // 7일 만료
+        Timestamp expiryDate = new Timestamp(new Date().getTime() + 3600000); // 1시간 만료
         RefreshToken refreshToken = new RefreshToken(user, token, expiryDate);
         refreshTokenRepository.save(refreshToken);
         return token;

--- a/src/main/java/com/sparta/gathering/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/gathering/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.sparta.gathering.domain.user.service;
 import com.sparta.gathering.domain.user.dto.request.UserRequest;
 import com.sparta.gathering.domain.user.entity.User;
 import com.sparta.gathering.domain.user.enums.IdentityProvider;
+import jakarta.transaction.Transactional;
 
 import java.util.UUID;
 
@@ -12,13 +13,12 @@ public interface UserService {
 
     User findById(UUID userId);
 
-    void deleteUser(UUID userId);
+    void deleteUser(UUID userId, String tokenUserId);
 
     User findByEmail(String email);
 
     User findByProviderIdAndIdentityProvider(String providerId, IdentityProvider identityProvider);
 
-    User save(User user);
-
     User authenticateUser(String email, String password);
+
 }

--- a/src/main/java/com/sparta/gathering/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/user/service/UserServiceImpl.java
@@ -8,12 +8,14 @@ import com.sparta.gathering.domain.user.enums.IdentityProvider;
 import com.sparta.gathering.domain.user.enums.UserRole;
 import com.sparta.gathering.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
+@Slf4j
 @Service
 public class UserServiceImpl implements UserService {
 
@@ -29,7 +31,9 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public User createUser(UserRequest userRequest) {
-        // User 객체 생성
+        if (userRepository.findByEmail(userRequest.getEmail()).isPresent()) {
+            throw new BaseException(ExceptionEnum.USER_ALREADY_EXISTS);
+        }
         User user = User.createWithAutoUUID(
                 userRequest.getEmail(),
                 userRequest.getNickName(),
@@ -40,14 +44,34 @@ public class UserServiceImpl implements UserService {
         return userRepository.save(user);
     }
 
-    @Override
     @Transactional
-    public void deleteUser(UUID userId) {
+    @Override
+    public void deleteUser(UUID userId, String tokenUserId) {
+
+        // 토큰에서 추출된 userId가 없을 경우 예외 발생
+        if (tokenUserId == null || tokenUserId.isEmpty()) {
+            throw new BaseException(ExceptionEnum.UNAUTHORIZED_ACTION); // 권한 없음 처리
+        }
+
+        // 요청된 userId와 토큰에서 추출된 userId가 일치하는지 확인
+        if (!userId.toString().equals(tokenUserId)) {
+            throw new BaseException(ExceptionEnum.UNAUTHORIZED_ACTION); // 권한 없음 처리
+        }
+
+        // 유저 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BaseException(ExceptionEnum.USER_NOT_FOUND));
+
+        // 이미 삭제된 사용자일 경우 예외 발생
+        if (user.getDeletedAt() != null) {
+            throw new BaseException(ExceptionEnum.ALREADY_DELETED);
+        }
+
         // 소프트 삭제 처리
-        user.deleteUser();
+        user.setDeletedAt();
+        userRepository.save(user);
     }
+
 
     @Override
     public User findById(UUID userId) {
@@ -65,11 +89,6 @@ public class UserServiceImpl implements UserService {
     public User findByProviderIdAndIdentityProvider(String providerId, IdentityProvider identityProvider) {
         return userRepository.findByProviderIdAndIdentityProvider(providerId, identityProvider)
                 .orElseThrow(() -> new BaseException(ExceptionEnum.USER_NOT_FOUND));
-    }
-
-    @Override
-    public User save(User user) {
-        return userRepository.save(user);
     }
 
     public User authenticateUser(String email, String rawPassword) {

--- a/tset.http
+++ b/tset.http
@@ -1,9 +1,15 @@
+@base_url = http://localhost:8080
+
+@userId = c0b9313f-cc7e-4dd4-a3c0-a64c52e1dcd9
+
+@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI2ODllMWY3Mi1hNTM2LTQ4ZjgtYTllNC0wZWQ0OTg2YmYyYjIiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJuaWNrTmFtZSI6Iu2Zjeq4uOuPmSIsInVzZXJSb2xlIjoiUk9MRV9VU0VSIiwiZXhwIjoxNzI5Njc1Nzc3LCJpYXQiOjE3Mjk2NzIxNzd9.2vEL5j5sT1ryslu4ltBpNKJ4G-5Hs1HZw-3kQz6PT38
+
 ### 회원가입 요청
-POST http://localhost:8080/api/users/signup
+POST {{base_url}}/api/users/signup
 Content-Type: application/json
 
 {
-  "email": "test1323@example.com",
+  "email": "test@example.com",
   "nickName": "홍길동",
   "password": "password123",
   "identityProvider": "NONE"
@@ -11,7 +17,7 @@ Content-Type: application/json
 
 
 ### 일반 로그인 요청
-POST http://localhost:8080/api/auth/login
+POST {{base_url}}/api/auth/login
 Content-Type: application/json
 
 {
@@ -19,9 +25,14 @@ Content-Type: application/json
   "password": "password123"
 }
 
+### 회원탈퇴 요청
+PATCH {{base_url}}/api/users/{{userId}}
+Authorization: Bearer {{jwt_token}}
+Content-Type: application/json
+
 
 ### Refresh Token을 통한 Access Token 재발급 요청
-POST http://localhost:8080/api/auth/token/refresh
+POST {{base_url}}/api/auth/token/refresh
 Content-Type: application/json
 
 {


### PR DESCRIPTION
탈퇴기능 구현 도중
기존 key = Keys.hmacShaKeyFor(bytes); 에서는 
잘못된 포맷이나 인코딩 문제로 인해
디코딩이 제대로 이루어지지 않아서 생성된 토큰에 서명 키가 null값이 되어
 key = Keys.hmacShaKeyFor(decodedKey);로 변경하여 정상 동작하도록 변경하고 회원 탈퇴기능 구현 완료하였습니다.