### PR TITLE
Feature/minji : JPQL로 작성된 Get 요청 API, Query DSL로 변환 완료

### DIFF
--- a/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
@@ -107,7 +107,7 @@ public class GatherController {
     }
 
     //title 검색
-    @Operation(summary = "title 검색", description = "%like% 검색 방식입니다." +
+    @Operation(summary = "title 검색", description = "contain 검색 방식입니다." +
             "page size는 10입니다.")
     @GetMapping("/title")
     public ApiResponse<SearchResponse> searchTitles(
@@ -115,7 +115,14 @@ public class GatherController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size){
         Pageable pageable = PageRequest.of(page - 1, size);
-        Page<Gather> titleList = gatherService.find
+        Page<Gather> titleList = gatherService.findByTitles(pageable, title);
+        SearchResponse response = new SearchResponse(
+                titleList.getContent(), // Gather 리스트
+                titleList.getNumber(), // 현재 페이지 번호
+                titleList.getTotalPages(), // 총 페이지 수
+                titleList.getTotalElements() // 총 요소 수
+        );
+        return ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
     }
 
     //랭킹 조회

--- a/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
@@ -96,7 +96,7 @@ public class GatherController {
             @RequestParam(defaultValue = "10") int size
     ) {
         Pageable pageable = PageRequest.of(page - 1, size);
-        Page<Gather> searchList = gatherService.findTitle(pageable, hashTagName);
+        Page<Gather> searchList = gatherService.findByHashTags(pageable, hashTagName);
         SearchResponse response = new SearchResponse(
                 searchList.getContent(), // Gather 리스트
                 searchList.getNumber(), // 현재 페이지 번호
@@ -104,6 +104,18 @@ public class GatherController {
                 searchList.getTotalElements() // 총 요소 수
         );
         return ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+    }
+
+    //title 검색
+    @Operation(summary = "title 검색", description = "%like% 검색 방식입니다." +
+            "page size는 10입니다.")
+    @GetMapping("/title")
+    public ApiResponse<SearchResponse> searchTitles(
+            @RequestParam(value = "title")String title,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size){
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Gather> titleList = gatherService.find
     }
 
     //랭킹 조회

--- a/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepository.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepository.java
@@ -13,4 +13,6 @@ public interface GatherCustomRepository {
     Page<Gather> findByKeywords(Pageable pageable, List<String> hashTagName);
 
     Page<Gather> findByTitle(Pageable pageable, String title);
+
+    Page<Gather> findByCategoryWithHashTags(Pageable pageable, Long categoryId);
 }

--- a/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepository.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepository.java
@@ -11,4 +11,6 @@ public interface GatherCustomRepository {
     Optional<Gather> findByIdWithBoardAndSchedule(Long gatherId);
 
     Page<Gather> findByKeywords(Pageable pageable, List<String> hashTagName);
+
+    Page<Gather> findByTitle(Pageable pageable, String title);
 }

--- a/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepositoryImpl.java
@@ -51,22 +51,51 @@ public class GatherCustomRepositoryImpl implements GatherCustomRepository {
     }
 
     @Override
-    public Page<Gather> findByTitle(Pageable pageable, String title){
-       List<Gather> result = q.selectFrom(gather)
-               .leftJoin(gather.hashTagList, hashTag).fetchJoin()
-               .where(
-                       gather.title.contains(title)
-                               .and(gather.deletedAt.isNull())
+    public Page<Gather> findByTitle(Pageable pageable, String title) {
+        List<Gather> result = q.selectFrom(gather)
+                .leftJoin(gather.hashTagList, hashTag).fetchJoin()
+                .where(
+                        gather.title.contains(title)
+                                .and(gather.deletedAt.isNull())
 
-               )
-               .offset(pageable.getOffset())
-               .limit(pageable.getPageSize())
-               .fetch();
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
 
+        Long count = q.select(gather.count())
+                .from(gather)
+                .where(
+                        gather.title.contains(title)
+                                .and(gather.deletedAt.isNull())
+                )
+                .fetchOne();
+        if (count == null) count = 0L;
+        return new PageImpl<>(result, pageable, count);
+    }
 
-       Long count = q.select(gather.count())
-               .from(gather)
-               .fetchOne();
+    @Override
+    public Page<Gather> findByCategoryWithHashTags(Pageable pageable, Long categoryId){
+        List<Gather> result =  q.selectFrom(gather)
+                .leftJoin(gather.hashTagList, hashTag).fetchJoin()
+                .leftJoin(gather.category).fetchJoin()
+                .where(
+                        gather.category.id.eq(categoryId)
+                                .and(gather.deletedAt.isNull())
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = q.select(gather.count())
+                .from(gather)
+                .where(
+                        gather.category.id.eq(categoryId)
+                                .and(gather.deletedAt.isNull())
+                )
+                .fetchOne();
+
+        if (count == null) count = 0L;
 
         return new PageImpl<>(result, pageable, count);
     }

--- a/src/main/java/com/sparta/gathering/domain/gather/repository/GatherRepository.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/repository/GatherRepository.java
@@ -1,26 +1,13 @@
 package com.sparta.gathering.domain.gather.repository;
 
 import com.sparta.gathering.domain.gather.entity.Gather;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 
 public interface GatherRepository extends JpaRepository<Gather, Long>, GatherCustomRepository {
 
-    @Query("SELECT g FROM Gather g " +
-            "JOIN FETCH g.category c " +
-            "LEFT JOIN FETCH g.hashTagList h " +
-            "WHERE g.category.id = :categoryId " +
-            "AND g.deletedAt IS NULL " +
-            "ORDER BY g.createdAt DESC")
-    Page<Gather> findByCategoryWithHashTags(@Param("categoryId") Pageable pageable, Long categoryId);
-
     // 생성일 기준 내림차순 정렬 후 상위 5개 모임 조회
     List<Gather> findTop5ByOrderByCreatedAtDesc();
-
 }

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
@@ -21,7 +21,7 @@ public interface GatherService {
 
     Page<Gather> gathers(Pageable pageable, Long categoryId);
 
-    Page<Gather> findTitle(Pageable pageable, List<String> hashTagName);
+    Page<Gather> findByHashTags(Pageable pageable, List<String> hashTagName);
 
     List<RankResponse> ranks();
 

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
@@ -28,4 +28,6 @@ public interface GatherService {
     GatherResponse getDetails(Long gatherId);
 
     List<NewGatherResponse> newCreatedGatherList();
+
+    Page<Gather> findByTitles(Pageable pageable, String title);
 }

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
@@ -147,6 +147,12 @@ public class GatherServiceImpl implements GatherService {
         return new GatherResponse(gather);
     }
 
+    @Transactional(readOnly = true)
+    @Override
+    public Page<Gather> findByTitles(Pageable pageable, String title){
+        return gatherRepository.findByTitle(pageable, title);
+    }
+
     // 새로운 모임 5개 조회
     @Transactional(readOnly = true)
     public List<NewGatherResponse> newCreatedGatherList() {

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
@@ -113,7 +113,7 @@ public class GatherServiceImpl implements GatherService {
 
     @Transactional(readOnly = true)
     @Override
-    public Page<Gather> findTitle(Pageable pageable, List<String> hashTagName) {
+    public Page<Gather> findByHashTags(Pageable pageable, List<String> hashTagName) {
         return gatherRepository.findByKeywords(pageable, hashTagName);
     }
 

--- a/src/main/resources/api/All_Api_Test.http
+++ b/src/main/resources/api/All_Api_Test.http
@@ -2,7 +2,7 @@
 
 @user_Id = 4245716d-9ed2-439c-a2f0-a83b87facd9e
 
-@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMDk3NDA3MSwiZXhwIjoxNzMwOTc1ODcxfQ.UyHY3f-ou6Lmpe0L6FdxZCVy-lwhb67po2Srr2Unwh4
+@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMDk3NzE4MywiZXhwIjoxNzMwOTc4OTgzfQ.Q0_N2c5DYXlegWlyQR8pbQrs6PTApr6BvRdA75h9Q74
 
 @expired_jwt = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MjQ1NzE2ZC05ZWQyLTQzOWMtYTJmMC1hODNiODdmYWNkOWUiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfQURNSU4iLCJpYXQiOjE3MzAzNzI5OTksImV4cCI6MTczMDM3NDc5OX0.xlYiDp2ewoYVsAuRNPrKgk8WPUSwGDRvrNM1swZcgpg
 
@@ -145,7 +145,7 @@ Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
 ### title 검색
-GET {{base_url}}/api/gathers/title?title=테스트&page=1
+GET {{base_url}}/api/gathers/title?title=영화&page=1
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 

--- a/src/main/resources/api/All_Api_Test.http
+++ b/src/main/resources/api/All_Api_Test.http
@@ -2,7 +2,7 @@
 
 @user_Id = 4245716d-9ed2-439c-a2f0-a83b87facd9e
 
-@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMDk2MDk5MCwiZXhwIjoxNzMwOTYyNzkwfQ.6sOoaxa_DlX6DUWcI_JucXZF_DxkVMIPVGMziF89lE8
+@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMDk3NDA3MSwiZXhwIjoxNzMwOTc1ODcxfQ.UyHY3f-ou6Lmpe0L6FdxZCVy-lwhb67po2Srr2Unwh4
 
 @expired_jwt = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MjQ1NzE2ZC05ZWQyLTQzOWMtYTJmMC1hODNiODdmYWNkOWUiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfQURNSU4iLCJpYXQiOjE3MzAzNzI5OTksImV4cCI6MTczMDM3NDc5OX0.xlYiDp2ewoYVsAuRNPrKgk8WPUSwGDRvrNM1swZcgpg
 
@@ -144,6 +144,10 @@ GET {{base_url}}/api/gathers/search?hashTagName=20대&hashTagName=건강&page=2
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
+### title 검색
+GET {{base_url}}/api/gathers/title?title=테스트&page=1
+Content-Type: application/json
+Authorization: Bearer {{jwt_token}}
 
 ### 동네 조회
 GET {{base_url}}/api/gathers/rank


### PR DESCRIPTION
# 변경사항
1.  GatherController의 `findTitle()`메서드가 `findByHashTags()`로 변경되었습니다.
2. GatherRepository에 있던 `findByCategoryWithHashTags()`메서드가 `GatherCustomRepository`로 이동하였습니다.
3. 모든 Query DSL에 `.and(gather.deletedAt.isNull())`쿼리가 추가되었습니다.

# 추가사항
1. gather의 title로 검색이 가능한 searchTitles API가 추가되었습니다.