### PR TITLE
Refactor:  상위 5개의 순위를 조회가능한 top5Ranking 추가

### DIFF
--- a/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/controller/GatherController.java
@@ -70,7 +70,7 @@ public class GatherController {
     @Operation(summary = "카테고리별 검색", description = "카테고리별로 모임조회사 가능합니다." +
             "page size는 10입니다.")
     @GetMapping("/{categoryId}")
-    public ApiResponse<CategoryListResponse> gathers(
+    public ResponseEntity<ApiResponse<CategoryListResponse>> gathers(
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @PathVariable Long categoryId) {
@@ -83,14 +83,14 @@ public class GatherController {
                 gatherList.getTotalPages(), // 총 페이지 수
                 gatherList.getTotalElements() // 총 요소 수
         );
-
-        return ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        ApiResponse<CategoryListResponse> apiResponse = ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
     }
 
     @Operation(summary = "hashtag 검색", description = "2개 이상의 keyword로 hashtag를 가진 모임을 검색합니다." +
             "page size는 10입니다.")
     @GetMapping("/search")
-    public ApiResponse<SearchResponse> search(
+    public ResponseEntity<ApiResponse<SearchResponse>> search(
             @RequestParam(value = "hashTagName", required = false)List<String> hashTagName,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size
@@ -103,14 +103,15 @@ public class GatherController {
                 searchList.getTotalPages(), // 총 페이지 수
                 searchList.getTotalElements() // 총 요소 수
         );
-        return ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        ApiResponse<SearchResponse> apiResponse = ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
     }
 
     //title 검색
     @Operation(summary = "title 검색", description = "contain 검색 방식입니다." +
             "page size는 10입니다.")
     @GetMapping("/title")
-    public ApiResponse<SearchResponse> searchTitles(
+    public ResponseEntity<ApiResponse<SearchResponse>> searchTitles(
             @RequestParam(value = "title")String title,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size){
@@ -122,15 +123,16 @@ public class GatherController {
                 titleList.getTotalPages(), // 총 페이지 수
                 titleList.getTotalElements() // 총 요소 수
         );
-        return ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        ApiResponse<SearchResponse> apiResponse = ApiResponse.successWithData(response, ApiResponseEnum.GET_SUCCESS);
+        return ResponseEntity.status(HttpStatus.OK).body(apiResponse);
     }
 
-    //랭킹 조회
-    @Operation(summary = "모임 랭킹 조회", description = "어제까지 모임이 많이 생성된 지역입니다." +
-            "매일 0시 0분 0초에 갱신될 예정입니다.")
-    @GetMapping("/rank")
-    public List<RankResponse> zSetOperations() {
-        return gatherService.ranks();
+    @Operation(summary = "상위 5개 랭킹 조회", description = "Redis에 저장된 상위 5개 랭킹을 조회합니다.")
+    @GetMapping("/topRanking")
+    public ResponseEntity<ApiResponse<List<RankResponse>>> getTop5Ranking() {
+        List<RankResponse> top5RankingList = gatherService.getTop5Ranking();
+        return ResponseEntity.ok(ApiResponse.successWithData(top5RankingList,
+                ApiResponseEnum.GET_SUCCESS));
     }
 
     //gather 상세조회

--- a/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepositoryImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/repository/GatherCustomRepositoryImpl.java
@@ -75,8 +75,8 @@ public class GatherCustomRepositoryImpl implements GatherCustomRepository {
     }
 
     @Override
-    public Page<Gather> findByCategoryWithHashTags(Pageable pageable, Long categoryId){
-        List<Gather> result =  q.selectFrom(gather)
+    public Page<Gather> findByCategoryWithHashTags(Pageable pageable, Long categoryId) {
+        List<Gather> result = q.selectFrom(gather)
                 .leftJoin(gather.hashTagList, hashTag).fetchJoin()
                 .leftJoin(gather.category).fetchJoin()
                 .where(

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherService.java
@@ -23,7 +23,7 @@ public interface GatherService {
 
     Page<Gather> findByHashTags(Pageable pageable, List<String> hashTagName);
 
-    List<RankResponse> ranks();
+    List<RankResponse> getTop5Ranking();
 
     GatherResponse getDetails(Long gatherId);
 

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,7 +46,6 @@ public class GatherServiceImpl implements GatherService {
     private final GatherRepository gatherRepository;
     private final MemberRepository memberRepository;
     private final RedisTemplate<String, Object> redisTemplate;
-    private final ZSetOperations<String, Object> zsetOperations;
     private final MapRepository mapRepository;
 
 
@@ -117,25 +117,43 @@ public class GatherServiceImpl implements GatherService {
         return gatherRepository.findByKeywords(pageable, hashTagName);
     }
 
+    /**
+     * 매일 자정마다 실행되는 스케쥴러 입니다.
+     * 상위 5개의 데이터를 top5Ranking에 별도 저장후 기존 저장된 city는 삭제됩니다.
+     * 이후 다시 모임이 생성되면 city역시 다시 저장됩니다.
+     */
+    @Transactional(readOnly = true)
+    @Scheduled(cron = "0 0 0 * * *")
+    public void ranks() {
+        // 1. 상위 5개 데이터 조회
+        Set<ZSetOperations.TypedTuple<Object>> top5 = redisTemplate.opsForZSet().reverseRangeWithScores("city", 0, 4);
+
+        // 2. 상위 5개 데이터를 별도의 키에 저장 (top5Ranking)
+        if (top5 != null && !top5.isEmpty()) {
+            // 기존 top5Ranking에서 데이터가 있다면 6번째 이후 항목 삭제
+            redisTemplate.opsForZSet().removeRange("top5Ranking", 5, -1);
+
+            // 새 데이터를 top5Ranking에 추가
+            top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue(), tuple.getScore()));
+        } else {
+            // top5가 null이거나 비어있으면 그냥 새로운 데이터만 저장
+            top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue(), tuple.getScore()));
+        }
+
+        // 3. 기존 랭킹 데이터 삭제
+        redisTemplate.opsForZSet().removeRange("city", 0, -1);
+    }
+
     @Transactional(readOnly = true)
     @Override
-//    @Scheduled(cron = "*/10 * * * * *")
-    public List<RankResponse> ranks() {
-        Set<ZSetOperations.TypedTuple<Object>> rankingWithMembers = zsetOperations.reverseRangeWithScores("city", 0, 4);
+    public List<RankResponse> getTop5Ranking() {
+        // top5Ranking 키에서 상위 5개 데이터 조회
+        Set<ZSetOperations.TypedTuple<Object>> top5 = redisTemplate.opsForZSet().reverseRangeWithScores("top5Ranking", 0, 4);
 
-        List<RankResponse> rankResponses = rankingWithMembers == null ? Collections.emptyList()
-                : rankingWithMembers.stream().map(tuple -> {
-                    Double score = tuple.getScore();
-                    String value = tuple.getValue() == null ? null : tuple.getValue().toString();
-
-                    return new RankResponse(score, value);
-                })
+        // 조회된 데이터를 RankResponse 리스트로 변환
+        return top5 == null ? Collections.emptyList()
+                : top5.stream().map(tuple -> new RankResponse(tuple.getScore(), tuple.getValue().toString()))
                 .collect(Collectors.toList());
-        // 콘솔에 출력
-        rankResponses.forEach(rankResponse ->
-                System.out.println("Score: " + rankResponse.getScore() + ", Adress: " + rankResponse.getAdress())
-        );
-        return rankResponses;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
+++ b/src/main/java/com/sparta/gathering/domain/gather/service/GatherServiceImpl.java
@@ -134,10 +134,12 @@ public class GatherServiceImpl implements GatherService {
             redisTemplate.opsForZSet().removeRange("top5Ranking", 5, -1);
 
             // 새 데이터를 top5Ranking에 추가
-            top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue(), tuple.getScore()));
+            top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue().toString(), tuple.getScore()));
         } else {
             // top5가 null이거나 비어있으면 그냥 새로운 데이터만 저장
-            top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue(), tuple.getScore()));
+            if (top5 != null) {
+                top5.forEach(tuple -> redisTemplate.opsForZSet().add("top5Ranking", tuple.getValue().toString(), tuple.getScore()));
+            }
         }
 
         // 3. 기존 랭킹 데이터 삭제
@@ -151,7 +153,7 @@ public class GatherServiceImpl implements GatherService {
         Set<ZSetOperations.TypedTuple<Object>> top5 = redisTemplate.opsForZSet().reverseRangeWithScores("top5Ranking", 0, 4);
 
         // 조회된 데이터를 RankResponse 리스트로 변환
-        return top5 == null ? Collections.emptyList()
+        return (top5 == null || top5.isEmpty()) ? Collections.emptyList()
                 : top5.stream().map(tuple -> new RankResponse(tuple.getScore(), tuple.getValue().toString()))
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/api/All_Api_Test.http
+++ b/src/main/resources/api/All_Api_Test.http
@@ -2,7 +2,7 @@
 
 @user_Id = 4245716d-9ed2-439c-a2f0-a83b87facd9e
 
-@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMTI5OTUwOCwiZXhwIjoxNzMxMzAxMzA4fQ.GR6V2wnbClzfjkLr81ziBmw-3YMa7Feg3Rh1msgxyd0
+@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMTMwMTMzOSwiZXhwIjoxNzMxMzAzMTM5fQ.eetPnHY-1l8qnCy4E0hpbadJUTZDV77za91LyRQnA80
 
 @expired_jwt = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MjQ1NzE2ZC05ZWQyLTQzOWMtYTJmMC1hODNiODdmYWNkOWUiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfQURNSU4iLCJpYXQiOjE3MzAzNzI5OTksImV4cCI6MTczMDM3NDc5OX0.xlYiDp2ewoYVsAuRNPrKgk8WPUSwGDRvrNM1swZcgpg
 
@@ -99,7 +99,7 @@ Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
 ### 모임 생성
-POST {{base_url}}/api/gathers/2
+POST {{base_url}}/api/gathers/{{category_Id}}
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
@@ -107,7 +107,7 @@ Authorization: Bearer {{jwt_token}}
   "title": "즐거운 풋살모임",
   "description": "같이 공차실분",
   "hashtags": ["futsal","실내"],
-  "addressName": "경기 광명시 소하동 1299",
+  "addressName": "서울 영등포구 여의도동 82-9",
   "latitude": "37.5134034035131",
   "longitude": "126.943292835393"
 }
@@ -148,7 +148,7 @@ Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
 ### 동네 조회
-GET {{base_url}}/api/gathers/rank
+GET {{base_url}}/api/gathers/topRanking
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 

--- a/src/main/resources/api/All_Api_Test.http
+++ b/src/main/resources/api/All_Api_Test.http
@@ -2,7 +2,7 @@
 
 @user_Id = 4245716d-9ed2-439c-a2f0-a83b87facd9e
 
-@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMDk3NzE4MywiZXhwIjoxNzMwOTc4OTgzfQ.Q0_N2c5DYXlegWlyQR8pbQrs6PTApr6BvRdA75h9Q74
+@jwt_token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwNGE4OTY2OS0wZjA0LTQ2ZTctYTVlMy01YTQ1MWZjZjQ5MzgiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTczMTI5OTUwOCwiZXhwIjoxNzMxMzAxMzA4fQ.GR6V2wnbClzfjkLr81ziBmw-3YMa7Feg3Rh1msgxyd0
 
 @expired_jwt = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MjQ1NzE2ZC05ZWQyLTQzOWMtYTJmMC1hODNiODdmYWNkOWUiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJ1c2VyUm9sZSI6IlJPTEVfQURNSU4iLCJpYXQiOjE3MzAzNzI5OTksImV4cCI6MTczMDM3NDc5OX0.xlYiDp2ewoYVsAuRNPrKgk8WPUSwGDRvrNM1swZcgpg
 
@@ -99,7 +99,7 @@ Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
 ### 모임 생성
-POST {{base_url}}/api/gathers/{{category_Id}}
+POST {{base_url}}/api/gathers/2
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
@@ -107,11 +107,9 @@ Authorization: Bearer {{jwt_token}}
   "title": "즐거운 풋살모임",
   "description": "같이 공차실분",
   "hashtags": ["futsal","실내"],
-  "map": {
-    "addressName": "서울 동작구 노량진로 156",
-    "latitude": "126.943292835393",
-    "longitude": "37.5134034035131"
-  }
+  "addressName": "경기 광명시 소하동 1299",
+  "latitude": "37.5134034035131",
+  "longitude": "126.943292835393"
 }
 
 ### 모임 수정
@@ -140,7 +138,7 @@ Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 
 ### hashTag 검색
-GET {{base_url}}/api/gathers/search?hashTagName=20대&hashTagName=건강&page=2
+GET {{base_url}}/api/gathers/search?hashTagName=20대&hashTagName=건강&page=1
 Content-Type: application/json
 Authorization: Bearer {{jwt_token}}
 


### PR DESCRIPTION
# 추가사항 
1. 상위 5개의 순위를 조회가능한 top5Ranking API가 추가되었습니다.
- 전날 모임이 많이 만들어진 지역은 이곳에서 조회 가능하도록 변경하였습니다.
 - 데이터가 정상적으로 저장되지 않는 부분을 수정하였습니다.
 
# 변경 사항
1. 기존 랭킹을 조회하는 API에 `@Schedule`를 추가하여 매일 0시에 redis key:city에 저장된 1~5위 순위를  top5Ranking으로 옮겨 별도의 저장공간에 저장되도록 하였습니다.
2.  top5Ranking API의 주소가 `rank`에서 `topRanking`으로 변경되었습니다.
3. 일부 controller에서  ApiResponse.successWithData로 작성했던 Return방식을  ResponseEntity.status 방식으로 통일하였습니다